### PR TITLE
Add a {{$MODULE}} expansion

### DIFF
--- a/corpus/DZ-Test/.netrc
+++ b/corpus/DZ-Test/.netrc
@@ -1,0 +1,3 @@
+machine api.twitter.com
+  login jdoe@example.com
+  password example

--- a/corpus/DZ-Test/dist.ini
+++ b/corpus/DZ-Test/dist.ini
@@ -1,0 +1,15 @@
+name    = DZ-Test
+version = v1.2.2
+author  = E. Xavier Ample <example@example.org>
+license = Perl_5
+copyright_holder = E. Xavier Ample
+
+[@Filter]
+bundle = @FakeClassic
+remove = ConfirmRelease
+remove = FakeRelease
+[FakeUploader]
+[Twitter]
+hash_tags = #bar
+url_shortener = Metamark
+tweet_url = http://p3rl.org/{{$MODULE}}

--- a/corpus/DZ-Test/lib/DZ/Test.pm
+++ b/corpus/DZ-Test/lib/DZ/Test.pm
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+package DZ::Test;
+# ABSTRACT: this is a sample package for testing Dist::Zilla;
+
+sub main {
+  return 1;
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/Twitter.pm
+++ b/lib/Dist/Zilla/Plugin/Twitter.pm
@@ -87,6 +87,9 @@ sub after_release {
       AUTHOR_LC => lc $cpan_id,
       AUTHOR_PATH => $path,
     };
+    my $module = $zilla->name;
+    $module =~ s/-/::/g;
+    $stash->{MODULE} = $module;
 
     my $longurl = $self->fill_in_string($self->tweet_url, $stash);
     foreach my $service (($self->url_shortener, 'TinyURL')) { # Fallback to TinyURL on errors

--- a/t/module.t
+++ b/t/module.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+use LWP::TestUA; # mocked UA
+use Net::Netrc; # mocked version
+
+use Test::More 0.88;
+use Path::Class;
+
+use Dist::Zilla::App::Tester;
+use Test::DZil;
+
+## SIMPLE TEST WITH DZIL::APP TESTER
+
+$ENV{DZ_TWITTER_USERAGENT} = 'LWP::TestUA';
+
+my $dist = 'DZ-Test';
+my $result = test_dzil("corpus/$dist", [ qw(release) ]);
+
+is($result->exit_code, 0, "dzil release would have exited 0");
+
+my $module = $dist;
+$module =~ s/-/::/g;
+my $url = "http://p3rl.org/$module";
+my $msg = "[Twitter] Released $dist-v1.2.2 $url #bar";
+
+ok(
+  (grep { $_ eq $msg } @{ $result->log_messages }),
+  "we logged the Twitter message",
+) or diag "STDOUT:\n" . $result->output . "STDERR:\n" . $result->error;
+
+ok (
+   (grep { $_ eq '[Twitter] Trying Metamark' } @{ $result->log_messages }),
+   'Log claims we tried to use WWW::Shorten::Metamark',
+) or diag "STDOUT:\n" . $result->output . "STDERR:\n" . $result->error;
+
+done_testing;


### PR DESCRIPTION
`{{$MODULE}}` in `tweet_url` now expands to the module name (with `::`), which might be required for some URLs like http://p3rl.org.
