### PR TITLE
Added ability to include abstract in tweet

### DIFF
--- a/lib/Dist/Zilla/Plugin/Twitter.pm
+++ b/lib/Dist/Zilla/Plugin/Twitter.pm
@@ -190,7 +190,7 @@ You can use the {hash_tags} option to append hash tags (or anything,
 really) to the end of the message generated from {tweet}.
 
   [Twitter]
-  hash-tags = #perl #cpan #foo
+  hash_tags = #perl #cpan #foo
 
 =end wikidoc
 

--- a/lib/Dist/Zilla/Plugin/Twitter.pm
+++ b/lib/Dist/Zilla/Plugin/Twitter.pm
@@ -82,6 +82,7 @@ sub after_release {
 
     my $stash = {
       DIST => $zilla->name,
+      ABSTRACT => $zilla->abstract,
       VERSION => $zilla->version,
       TRIAL   => ( $zilla->is_trial ? '-TRIAL' : '' ),
       TARBALL => "$tgz",
@@ -173,6 +174,7 @@ appended to the {tweet} messsage.  The following variables are
 available for substitution in the URL and message templates:
 
       DIST        # Foo-Bar
+      ABSTRACT    # Foo-Bar is a module that FooBars
       VERSION     # 1.23
       TRIAL       # -TRIAL if is_trial, empty string otherwise.
       TARBALL     # Foo-Bar-1.23.tar.gz


### PR DESCRIPTION
Just added 'ABSTRACT => $zilla->abstract' to stash variable and updated pod to show the change.
