### PR TITLE
Check for common twitter config errors before releasing

### DIFF
--- a/corpus/DZBad1/dist.ini
+++ b/corpus/DZBad1/dist.ini
@@ -1,0 +1,13 @@
+name    = DZBad1
+version = 0.001
+author  = E. Xavier Ample <example@example.org>
+license = Perl_5
+copyright_holder = E. Xavier Ample
+
+[@Filter]
+bundle = @FakeClassic
+remove = ConfirmRelease
+remove = FakeRelease
+[FakeUploader]
+[Twitter]
+hash_tags = #foo

--- a/corpus/DZBad1/lib/DZBad1.pm
+++ b/corpus/DZBad1/lib/DZBad1.pm
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+package DZBad1;
+# ABSTRACT: this is a sample package for testing Dist::Zilla;
+
+sub main {
+  return 1;
+}
+
+1;

--- a/corpus/DZBad2/.netrc
+++ b/corpus/DZBad2/.netrc
@@ -1,0 +1,3 @@
+machine some.other.host
+  login jdoe@example.com
+  password example

--- a/corpus/DZBad2/dist.ini
+++ b/corpus/DZBad2/dist.ini
@@ -1,0 +1,13 @@
+name    = DZBad2
+version = 0.001
+author  = E. Xavier Ample <example@example.org>
+license = Perl_5
+copyright_holder = E. Xavier Ample
+
+[@Filter]
+bundle = @FakeClassic
+remove = ConfirmRelease
+remove = FakeRelease
+[FakeUploader]
+[Twitter]
+hash_tags = #foo

--- a/corpus/DZBad2/lib/DZBad2.pm
+++ b/corpus/DZBad2/lib/DZBad2.pm
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+package DZBad2;
+# ABSTRACT: this is a sample package for testing Dist::Zilla;
+
+sub main {
+  return 1;
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/Twitter.pm
+++ b/lib/Dist/Zilla/Plugin/Twitter.pm
@@ -12,12 +12,15 @@ use Moose 0.99;
 use Math::BigFloat;
 use Net::Twitter 3 ();
 use Net::Netrc;
+use Path::Class;
+use Try::Tiny;
 use WWW::Shorten::Simple ();  # A useful interface to WWW::Shorten
 use WWW::Shorten 3.02 ();     # For latest updates to dead services
 use WWW::Shorten::TinyURL (); # Our fallback
 use namespace::autoclean 0.09;
 
 # extends, roles, attributes, etc.
+with 'Dist::Zilla::Role::BeforeRelease';
 with 'Dist::Zilla::Role::AfterRelease';
 with 'Dist::Zilla::Role::TextTemplate';
 
@@ -62,6 +65,20 @@ END
 );
 
 # methods
+
+sub before_release {
+    my $self = shift;
+
+    ### check to make sure we have twitter credentials...
+    try {
+        Net::Netrc->lookup('api.twitter.com')->lpa;
+    }
+    catch {
+        confess "Can't get Twitter credentials from .netrc: $_";
+    };
+
+    return;
+}
 
 sub after_release {
     my $self = shift;
@@ -137,6 +154,7 @@ __END__
 
 =for Pod::Coverage
   after_release
+  before_release
 
 =begin wikidoc
 

--- a/t/before-dies-on-no-netrc.t
+++ b/t/before-dies-on-no-netrc.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Net::Netrc; # non-mocked version
+use lib 't/lib';
+use File::chdir;
+use LWP::TestUA; # mocked UA
+
+use Test::More 0.88;
+use Test::Fatal;
+use Path::Class;
+
+use Dist::Zilla::App::Tester;
+use Test::DZil;
+
+## SIMPLE TEST WITH DZIL::APP TESTER
+
+$ENV{DZ_TWITTER_USERAGENT} = 'LWP::TestUA';
+
+my @test_data = (
+    [ DZBad2 => qr/Can't get Twitter credentials from .netrc:/ ],
+);
+
+for my $data (@test_data) {
+
+    my ($dist, $error_re) = @$data;
+    local $ENV{HOME} = dir('.', 'corpus', $dist)->absolute->stringify;
+    my $result = test_dzil("corpus/$dist", [ qw(release) ]);
+
+    like $result->error, $error_re, 'got the error message we were expecting';
+}
+
+done_testing;


### PR DESCRIPTION
Here we add the BeforeRelease role, so that we can validate parts of our configuration, rather than allowing that to possibly Messify(tm) the after release process by dying because we don't have the proper twitter authentication information.

Originally I wrote this with multiple checks in mind.  However, it turned out to really be one check, to ensure we have twitter credentials available.
